### PR TITLE
changed solr http_port to an integer rather than a string

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -15,7 +15,7 @@
 # [*central_repo*]  The repo in the general nexus instance to get artifacts from
 #
 class solr (
-  $port          = '7000',
+  $port          = 7000,
   $version       = '4.6.0',
   $solr_home     = '/home/tomcat7/solr_home',
   $slf4j_version = '1.6.6',


### PR DESCRIPTION
http_port as a string is causing a problem while installing the catalog, bombing out on line 82 of tomcat instance.pp file:

Error: Evaluation Error: Comparison of: String <= Integer, is not possible. Caused by 'A String is not comparable to a non String'. at /modules/tomcat/manifests/instance.pp:87:32 on node 663875ce8fe5.marine.ie